### PR TITLE
Deal with references to Secrets Manager secrets

### DIFF
--- a/source-code/main.py
+++ b/source-code/main.py
@@ -58,8 +58,11 @@ class DBProvisioner(object):
         )
         returnval = response.get('Parameter').get('Value')
         if (name.startswith('/aws/reference/secretsmanager')):
-            val = json.loads(returnval)
-            returnval = val['password']
+            try:
+                val = json.loads(returnval)
+                returnval = val['password']
+            except ValueError as e:
+                pass
         return returnval
 
     @staticmethod

--- a/source-code/main.py
+++ b/source-code/main.py
@@ -8,7 +8,7 @@ Endpoint, engine and master username will be obtained through AWS RDS API, you
 just need to pass db instance identifier.
 
 Master user will be granted all permissions to the created database.
-If user or database already exist - they won't be created.
+If user or database already exists - they won't be created.
 
 Author: aleksandr.fofanov@quantumsoft.ru
 
@@ -100,7 +100,7 @@ class DBProvisioner(object):
         if info.provision_user:
             usernames = self._get_pg_usernames(cursor)
             if info.provision_user in usernames:
-                self.logger.warning("User '{}' won't be created because it's already exist".format(info.provision_user))
+                self.logger.warning("User '{}' won't be created because it already exists".format(info.provision_user))
             else:
                 self.logger.info("Creating user '{}'".format(info.provision_user))
 
@@ -115,7 +115,7 @@ class DBProvisioner(object):
 
         if info.provision_db_name in databases_names:
             self.logger.warning(
-                "Database '{}' won't be created because it's already exist".format(info.provision_db_name))
+                "Database '{}' won't be created because it already exists".format(info.provision_db_name))
         else:
             self.logger.info("Creating database '{}'".format(info.provision_db_name))
 
@@ -177,7 +177,7 @@ class DBProvisioner(object):
         if info.provision_user:
             usernames = self._get_mysql_usernames(cursor)
             if info.provision_user in usernames:
-                self.logger.warning("User '{}' won't be created because it's already exist".format(info.provision_user))
+                self.logger.warning("User '{}' won't be created because it already exists".format(info.provision_user))
             else:
                 self.logger.info("Creating user '{}'".format(info.provision_user))
 
@@ -197,7 +197,7 @@ class DBProvisioner(object):
         databases_names = self._get_mysql_databases_names(cursor)
 
         if info.provision_db_name in databases_names:
-            self.logger.warning("Database '{}' won't be created because it's already exist".format(
+            self.logger.warning("Database '{}' won't be created because it already exists".format(
                 info.provision_db_name
             ))
         else:

--- a/source-code/main.py
+++ b/source-code/main.py
@@ -20,6 +20,7 @@ import boto3
 import os
 from dataclasses import dataclass
 from typing import List
+import json
 
 import psycopg2
 import pymysql
@@ -55,7 +56,11 @@ class DBProvisioner(object):
             Name=name,
             WithDecryption=True
         )
-        return response.get('Parameter').get('Value')
+        returnval = response.get('Parameter').get('Value')
+        if (name.startswith('/aws/reference/secretsmanager')):
+            val = json.loads(returnval)
+            returnval = val['password']
+        return returnval
 
     @staticmethod
     def _get_pg_usernames(cursor) -> List[str]:


### PR DESCRIPTION
When attempting to [use SSM to reference SM secrets](https://docs.aws.amazon.com/systems-manager/latest/userguide/integration-ps-secretsmanager.html), the prefix `/aws/reference/secretsmanager` is used. This works fine for object retrieval, however the response.get('Parameter').get('Value') is not necessarily the password string, but more commonly a JSON object.  This PR deals with that difference as well as the need to add additional IAM permission to read from `secretsmanager`.

Closes #1 